### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/superagent": "^4.1.7",
     "@typescript-eslint/eslint-plugin": "^3.0.1",
     "@typescript-eslint/parser": "^3.0.1",
-    "cloudinary": "^1.21.0",
+    "cloudinary": "^2.5.1",
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",
     "form-data": "^3.0.0",


### PR DESCRIPTION
Upgraded Cloudinary to version 2.5.1 to resolve installation conflicts with `cloudinary` and `multer-storage-cloudinary`, caused by the previous version being locked at 1.21.0.